### PR TITLE
Added support for oblique gesture swipes.

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -31,14 +31,25 @@ void gebaar::config::Config::load_config()
     if (find_home_folder()) {
         if (find_config_file()) {
             config = cpptoml::parse_file(std::filesystem::path(config_file_path));
-            swipe_three_up_command = *config->get_qualified_as<std::string>("commands.swipe.three.up");
-            swipe_three_down_command = *config->get_qualified_as<std::string>("commands.swipe.three.down");
-            swipe_three_left_command = *config->get_qualified_as<std::string>("commands.swipe.three.left");
-            swipe_three_right_command = *config->get_qualified_as<std::string>("commands.swipe.three.right");
-            swipe_four_up_command = *config->get_qualified_as<std::string>("commands.swipe.four.up");
-            swipe_four_down_command = *config->get_qualified_as<std::string>("commands.swipe.four.down");
-            swipe_four_left_command = *config->get_qualified_as<std::string>("commands.swipe.four.left");
-            swipe_four_right_command = *config->get_qualified_as<std::string>("commands.swipe.four.right");
+
+            swipe_three_commands[1] = *config->get_qualified_as<std::string>("commands.swipe.three.left_up");
+            swipe_three_commands[2] = *config->get_qualified_as<std::string>("commands.swipe.three.up");
+            swipe_three_commands[3] = *config->get_qualified_as<std::string>("commands.swipe.three.right_up");
+            swipe_three_commands[4] = *config->get_qualified_as<std::string>("commands.swipe.three.left");
+            swipe_three_commands[6] = *config->get_qualified_as<std::string>("commands.swipe.three.right");
+            swipe_three_commands[7] = *config->get_qualified_as<std::string>("commands.swipe.three.left_down");
+            swipe_three_commands[8] = *config->get_qualified_as<std::string>("commands.swipe.three.down");
+            swipe_three_commands[9] = *config->get_qualified_as<std::string>("commands.swipe.three.right_down");
+
+            swipe_four_commands[1] = *config->get_qualified_as<std::string>("commands.swipe.four.left_up");
+            swipe_four_commands[2] = *config->get_qualified_as<std::string>("commands.swipe.four.up");
+            swipe_four_commands[3] = *config->get_qualified_as<std::string>("commands.swipe.four.right_up");
+            swipe_four_commands[4] = *config->get_qualified_as<std::string>("commands.swipe.four.left");
+            swipe_four_commands[6] = *config->get_qualified_as<std::string>("commands.swipe.four.right");
+            swipe_four_commands[7] = *config->get_qualified_as<std::string>("commands.swipe.four.left_down");
+            swipe_four_commands[8] = *config->get_qualified_as<std::string>("commands.swipe.four.down");
+            swipe_four_commands[9] = *config->get_qualified_as<std::string>("commands.swipe.four.right_down");
+
             loaded = true;
         }
     }

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -33,14 +33,9 @@ namespace gebaar::config {
 
         void load_config();
 
-        std::string swipe_four_up_command;
-        std::string swipe_four_down_command;
-        std::string swipe_four_left_command;
-        std::string swipe_four_right_command;
-        std::string swipe_three_up_command;
-        std::string swipe_three_down_command;
-        std::string swipe_three_left_command;
-        std::string swipe_three_right_command;
+        std::string swipe_three_commands[9];
+        std::string swipe_four_commands[9];
+
     private:
         bool find_config_file();
 

--- a/src/io/input.cpp
+++ b/src/io/input.cpp
@@ -38,42 +38,39 @@ void gebaar::io::Input::handle_swipe_event_without_coords(libinput_event_gesture
         gesture_swipe_event.fingers = libinput_event_gesture_get_finger_count(gev);
     }
     else {
-        if (abs(gesture_swipe_event.x)>abs(gesture_swipe_event.y)) {
-            if (gesture_swipe_event.x<0) {
-                if (gesture_swipe_event.fingers==3) {
-                    std::system(config->swipe_three_left_command.c_str());
-                }
-                else if (gesture_swipe_event.fingers==4) {
-                    std::system(config->swipe_four_left_command.c_str());
-                }
+        double x = gesture_swipe_event.x;
+        double y = gesture_swipe_event.y;
+        int swipe_type = 5; // middle = no swipe
+                           // 1 = left_up, 2 = up, 3 = right_up...
+                           // 1 2 3
+                           // 4 5 6
+                           // 7 8 9
+        const double OBLIQUE_RATIO = 0.414; // =~ tan(22.5);
+
+        if (abs(x) > abs(y)) {
+            // left or right swipe
+            swipe_type += x < 0 ? -1 : 1;
+
+            // check for oblique swipe
+            if (abs(y) / abs(x) > OBLIQUE_RATIO) {
+                swipe_type += y < 0 ? -3 : 3;
             }
-            else {
-                if (gesture_swipe_event.fingers==3) {
-                    std::system(config->swipe_three_right_command.c_str());
-                }
-                else if (gesture_swipe_event.fingers==4) {
-                    std::system(config->swipe_four_right_command.c_str());
-                }
-            }
-        }
-        else {
-            if (gesture_swipe_event.y<0) {
-                if (gesture_swipe_event.fingers==3) {
-                    std::system(config->swipe_three_up_command.c_str());
-                }
-                else if (gesture_swipe_event.fingers==4) {
-                    std::system(config->swipe_four_up_command.c_str());
-                }
-            }
-            else {
-                if (gesture_swipe_event.fingers==3) {
-                    std::system(config->swipe_three_down_command.c_str());
-                }
-                else if (gesture_swipe_event.fingers==4) {
-                    std::system(config->swipe_four_down_command.c_str());
-                }
+        } else {
+            // up of down swipe
+            swipe_type += y < 0 ? -3 : 3;
+
+            // check for oblique swipe
+            if (abs(x) / abs(y) > OBLIQUE_RATIO) {
+                swipe_type += x < 0 ? -1 : 1;
             }
         }
+
+        if (gesture_swipe_event.fingers == 3) {
+            std::system(config->swipe_three_commands[swipe_type].c_str());
+        } else if (gesture_swipe_event.fingers == 4) {
+            std::system(config->swipe_four_commands[swipe_type].c_str());
+        }
+
         gesture_swipe_event = {};
     }
 }


### PR DESCRIPTION
To add the support the config class was modified to include the new
gestures types: left_up, right_up, left_down, right_down.
Also changed the way the commands are saved in the config class, so
there won't be a need for a lot of if statements to handle 4 finger
swipes and 3 finger swipes.
Finally, the handle_swipe_event_without_coords was modified to detect
the oblique swipes.
Addresses issue #2 