### PR TITLE
Ignore first pair of coordinates, which are occasionally far off.

### DIFF
--- a/src/io/input.cpp
+++ b/src/io/input.cpp
@@ -54,8 +54,8 @@ void gebaar::io::Input::handle_swipe_event_without_coords(libinput_event_gesture
 {
     if (begin) {
         gesture_swipe_event.fingers = libinput_event_gesture_get_finger_count(gev);
-    }
-    else {
+        has_received_updates = false;
+    } else {
         double x = gesture_swipe_event.x;
         double y = gesture_swipe_event.y;
         int swipe_type = 5; // middle = no swipe
@@ -99,8 +99,12 @@ void gebaar::io::Input::handle_swipe_event_without_coords(libinput_event_gesture
  */
 void gebaar::io::Input::handle_swipe_event_with_coords(libinput_event_gesture* gev)
 {
-    gesture_swipe_event.x += libinput_event_gesture_get_dx(gev);
-    gesture_swipe_event.y += libinput_event_gesture_get_dy(gev);
+    if (has_received_updates) {
+        gesture_swipe_event.x += libinput_event_gesture_get_dx(gev);
+        gesture_swipe_event.y += libinput_event_gesture_get_dy(gev);
+    } else {
+        has_received_updates = true;
+    }
 }
 
 /**

--- a/src/io/input.h
+++ b/src/io/input.h
@@ -44,6 +44,8 @@ namespace gebaar::io {
     private:
         std::shared_ptr<gebaar::config::Config> config;
 
+        bool has_received_updates;
+
         struct libinput* libinput;
         struct libinput_event* libinput_event;
         struct udev* udev;


### PR DESCRIPTION
I noticed that on my machine, the first coordinates received from libinput occasionally are very far off, resulting in a wrong swipe. Ignoring the first update seems to fix the issue for my while still recognized valid swipes.