### PR TITLE
Added support for pinch in/out gestures

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -56,6 +56,9 @@ void gebaar::config::Config::load_config()
             swipe_four_commands[8] = *config->get_qualified_as<std::string>("commands.swipe.four.down");
             swipe_four_commands[9] = *config->get_qualified_as<std::string>("commands.swipe.four.right_down");
 
+            pinch_in_command = *config->get_qualified_as<std::string>("commands.pinch.in");
+            pinch_out_command = *config->get_qualified_as<std::string>("commands.pinch.out");
+
             loaded = true;
         }
     }

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -35,6 +35,8 @@ namespace gebaar::config {
 
         std::string swipe_three_commands[10];
         std::string swipe_four_commands[10];
+        std::string pinch_in_command;
+        std::string pinch_out_command;
 
     private:
         bool config_file_exists();

--- a/src/io/input.cpp
+++ b/src/io/input.cpp
@@ -104,6 +104,24 @@ void gebaar::io::Input::handle_swipe_event_with_coords(libinput_event_gesture* g
 }
 
 /**
+ * Handles pinch gesture events.
+ * Called at the end of the pinch event, so we just need to determine the pinch type.
+ *
+ * @param gev Gesture Event
+ */
+void gebaar::io::Input::handle_pinch_event(libinput_event_gesture* gev)
+{
+    double scale = libinput_event_gesture_get_scale(gev);
+    if (scale < 1) {
+        // pinch out
+        std::system(config->pinch_out_command.c_str());
+    } else {
+        // pinch in
+        std::system(config->pinch_in_command.c_str());
+    }
+}
+
+/**
  * Initialize the input system
  * @return bool
  */
@@ -214,6 +232,7 @@ void gebaar::io::Input::handle_event()
         case LIBINPUT_EVENT_GESTURE_PINCH_UPDATE:
             break;
         case LIBINPUT_EVENT_GESTURE_PINCH_END:
+            handle_pinch_event(libinput_event_get_gesture_event(libinput_event));
             break;
         case LIBINPUT_EVENT_SWITCH_TOGGLE:
             break;

--- a/src/io/input.h
+++ b/src/io/input.h
@@ -74,6 +74,8 @@ namespace gebaar::io {
         void handle_swipe_event_without_coords(libinput_event_gesture* gev, bool begin);
 
         void handle_swipe_event_with_coords(libinput_event_gesture* gev);
+
+        void handle_pinch_event(libinput_event_gesture* gev);
     };
 }
 


### PR DESCRIPTION
Initial support for pinch in/out gestures. libinput does differentiate between 2/3/4 fingers pinch events so adding support for all the different variations can be done, but reliably executing the different variants isn't really easy.