### PR TITLE
Add a desktop file

### DIFF
--- a/gebaar-libinput.desktop
+++ b/gebaar-libinput.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=gebaar-libinput
+Comment=Touchpad Gesture Daemon for libinput
+Exec=/usr/bin/gebaard -b
+StartupNotify=false
+Terminal=false
+Type=Application
+X-GNOME-Autostart-enabled=true


### PR DESCRIPTION
Users can copy this desktop file to $XDG_CONFIG_HOME/autostart to enable
autostart on most desktop environments.

![settings](https://i.imgur.com/OxIeL7l.png)