### PR TITLE
Fix crash, when XDG_CONFIG_HOME is unset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,9 @@ add_executable(gebaard
         src/config/config.cpp
         src/config/config.h
         src/daemonizer.cpp
-        src/daemonizer.h)
+        src/daemonizer.h
+        src/util.cpp
+        src/util.h)
 
 find_package(PkgConfig)
 if (PKG_CONFIG_FOUND)

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -19,6 +19,7 @@
 
 #include <zconf.h>
 #include "config.h"
+#include "../util.h"
 
 /**
  * Check if config file exists at current path
@@ -68,10 +69,10 @@ void gebaar::config::Config::load_config()
  */
 bool gebaar::config::Config::find_config_file()
 {
-    std::string temp_path = getenv("XDG_CONFIG_HOME");
+    std::string temp_path = gebaar::util::stringFromCharArray(getenv("XDG_CONFIG_HOME"));
     if (temp_path.empty()) {
         // first get the path to HOME
-        temp_path = getenv("HOME");
+        temp_path = gebaar::util::stringFromCharArray(getenv("HOME"));
         if (temp_path.empty()) {
             temp_path = getpwuid(getuid())->pw_dir;
         }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,0 +1,29 @@
+/*
+    gebaar
+    Copyright (C) 2019   coffee2code
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "util.h"
+
+/**
+ * @brief Safely converts a char array to a std::string
+ * @param charArr The char array to convert
+ * @return charArr or an empty string, if charArr is a nullptr
+ */
+std::string gebaar::util::stringFromCharArray(char* charArr)
+{
+    return charArr == nullptr ? "" : charArr;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,28 @@
+/*
+    gebaar
+    Copyright (C) 2019   coffee2code
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef UTIL_H
+#define UTIL_H
+
+#include <string>
+
+namespace gebaar::util {
+    std::string stringFromCharArray(char* charArr);
+}
+
+#endif // UTIL_H


### PR DESCRIPTION
Regression from 41c7c05

Just using getenv directly and converting it to a std::string is dangerous. If getenv returns a nullptr - e.g. if the variable is unset - then the entire program crashes.

This fixes it by checking for nullptr first.