### PR TITLE
Don't crash when parsing options

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,25 +27,34 @@ gebaar::io::Input* input;
 
 int main(int argc, char* argv[])
 {
-    cxxopts::Options options(argv[0], "Gebaard Gestures Daemon");
+    try
+    {
+        cxxopts::Options options(argv[0], "Gebaard Gestures Daemon");
 
-    bool should_daemonize = false;
+        bool should_daemonize = false;
 
-    options.add_options()
-            ("b,background", "Daemonize", cxxopts::value(should_daemonize))
-            ("h,help", "Prints this help text");
+        options.add_options()
+                ("b,background", "Daemonize", cxxopts::value(should_daemonize))
+                ("h,help", "Prints this help text");
 
-    auto result = options.parse(argc, argv);
+        auto result = options.parse(argc, argv);
 
-    if (result.count("help")) {
-        std::cout << options.help() << std::endl;
-        exit(EXIT_SUCCESS);
+        if (result.count("help")) {
+            std::cout << options.help() << std::endl;
+            exit(EXIT_SUCCESS);
+        }
+
+        if (should_daemonize) {
+            auto *daemonizer = new gebaar::daemonizer::Daemonizer();
+            daemonizer->daemonize();
+        }
+
+    } catch (const cxxopts::OptionException& e)
+    {
+        std::cerr << "error parsing options: " << e.what() << std::endl;
+        exit(EXIT_FAILURE);
     }
 
-    if (should_daemonize) {
-        auto *daemonizer = new gebaar::daemonizer::Daemonizer();
-        daemonizer->daemonize();
-    }
     std::shared_ptr<gebaar::config::Config> config = std::make_shared<gebaar::config::Config>();
     input = new gebaar::io::Input(config);
     if (input->initialize()) {


### PR DESCRIPTION
Without catching the unknown option exception, gebaard crashes with an abort:
```
$ gebaard -d
terminate called after throwing an instance of 'cxxopts::option_not_exists_exception'
  what():  Option ‘d’ does not exist
[1]    11684 abort (core dumped)  gebaard -d
```

This pull request fixes this by catching the exception (as seen in https://github.com/jarro2783/cxxopts/blob/master/src/example.cpp), with the following result:
```
$ ./gebaard -d
error parsing options: Option ‘d’ does not exist
```

Thanks for creating gebaar! I finally got around to using it. It's a nice improvement to the alternatives. (Greetings from #bspwm!)