### PR TITLE
Added pinch gestures

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ right_down = ""
 down = ""
 left = ""
 right = ""
+
+[commands.pinch]
+in = ""
+out = ""
 ```
 
 ### Repository versions
@@ -77,6 +81,7 @@ down = "bspc node -f south"
 left = "bspc node -f west"
 right = "bspc node -f east"
 
+
 [commands.swipe.four]
 left_up = ""
 right_up = ""
@@ -86,6 +91,10 @@ right_down = ""
 down = ""
 left = "bspc desktop -f prev"
 right = "bspc desktop -f next"
+
+[commands.pinch]
+in = "xdotool key Control_L+equal"
+out = "xdotool key Control_L+minus"
 ```
 
 Add `gebaard -b` to `~/.config/bspwm/bspwmrc`
@@ -93,9 +102,12 @@ Add `gebaard -b` to `~/.config/bspwm/bspwmrc`
 ### State of the project
 
 - [x] Receiving swipe events from libinput
-- [ ] Receiving pinch/zoom events from libinput
+- [x] Receiving pinch/zoom events from libinput
+  - [ ] Support continous pinch
+  - [ ] Support pinch-and-rotate gestures
 - [ ] Receiving rotation events from libinput
 - [x] Converting libinput events to motions
 - [x] Running commands based on motions
 - [x] Refactor code to be up to Release standards, instead of testing-hell
+
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1,17 +1,17 @@
 /*
     gebaar
     Copyright (C) 2019   coffee2code
-    
+
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -60,6 +60,9 @@ void gebaar::config::Config::load_config()
             swipe_four_commands[7] = *config->get_qualified_as<std::string>("commands.swipe.four.left_down");
             swipe_four_commands[8] = *config->get_qualified_as<std::string>("commands.swipe.four.down");
             swipe_four_commands[9] = *config->get_qualified_as<std::string>("commands.swipe.four.right_down");
+
+            pinch_commands[0] = *config->get_qualified_as<std::string>("commands.pinch.out");
+            pinch_commands[1] = *config->get_qualified_as<std::string>("commands.pinch.in");
 
             loaded = true;
         }

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -1,17 +1,17 @@
 /*
     gebaar
     Copyright (C) 2019   coffee2code
-    
+
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -35,6 +35,7 @@ namespace gebaar::config {
 
         std::string swipe_three_commands[10];
         std::string swipe_four_commands[10];
+        std::string pinch_commands[10];
 
     private:
         bool config_file_exists();

--- a/src/io/input.cpp
+++ b/src/io/input.cpp
@@ -1,17 +1,17 @@
 /*
     gebaar
     Copyright (C) 2019   coffee2code
-    
+
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -40,6 +40,43 @@ bool gebaar::io::Input::initialize_context()
     udev = udev_new();
     libinput = libinput_udev_create_context(&libinput_interface, nullptr, udev);
     return libinput_udev_assign_seat(libinput, "seat0")==0;
+}
+
+
+
+/**
+ * Pinch Gesture
+ * Currently supporting only "one shot" pinch-in and pinch-out gestures.
+ * @param gev Gesture Event
+ * @param begin Boolean to denote begin or continuation of gesture.
+ **/
+void gebaar::io::Input::handle_pinch_event(libinput_event_gesture* gev, bool begin)
+{
+    if (begin) {
+        gesture_pinch_event.fingers = libinput_event_gesture_get_finger_count(gev);
+        // Reset pinch data
+        gesture_pinch_event.scale = 1.0;
+        gesture_pinch_event.executed = false;
+    }
+    else {
+        if (gesture_pinch_event.executed) return;
+        double new_scale = libinput_event_gesture_get_scale(gev);
+        if (new_scale > gesture_pinch_event.scale) {
+        // Scale up
+            if (gesture_pinch_event.scale * new_scale > 1.5) {
+                std::system(config->pinch_commands[0].c_str());
+                gesture_pinch_event.executed = true;
+            }
+        }
+        else {
+            // Scale Down
+            if (gesture_pinch_event.scale * new_scale < 0.5) {
+                std::system(config->pinch_commands[1].c_str());
+                gesture_pinch_event.executed = true;
+            }
+        }
+        gesture_pinch_event.scale = new_scale;
+    }
 }
 
 /**
@@ -169,6 +206,15 @@ void gebaar::io::Input::handle_event()
         case LIBINPUT_EVENT_GESTURE_SWIPE_END:
             handle_swipe_event_without_coords(libinput_event_get_gesture_event(libinput_event), false);
             break;
+        case LIBINPUT_EVENT_GESTURE_PINCH_BEGIN:
+            handle_pinch_event(libinput_event_get_gesture_event(libinput_event), true);
+            break;
+        case LIBINPUT_EVENT_GESTURE_PINCH_UPDATE:
+            handle_pinch_event(libinput_event_get_gesture_event(libinput_event), false);
+            break;
+        case LIBINPUT_EVENT_GESTURE_PINCH_END:
+            handle_pinch_event(libinput_event_get_gesture_event(libinput_event), false);
+            break;
         case LIBINPUT_EVENT_NONE:
             break;
         case LIBINPUT_EVENT_DEVICE_ADDED:
@@ -208,12 +254,6 @@ void gebaar::io::Input::handle_event()
         case LIBINPUT_EVENT_TABLET_PAD_RING:
             break;
         case LIBINPUT_EVENT_TABLET_PAD_STRIP:
-            break;
-        case LIBINPUT_EVENT_GESTURE_PINCH_BEGIN:
-            break;
-        case LIBINPUT_EVENT_GESTURE_PINCH_UPDATE:
-            break;
-        case LIBINPUT_EVENT_GESTURE_PINCH_END:
             break;
         case LIBINPUT_EVENT_SWITCH_TOGGLE:
             break;

--- a/src/io/input.h
+++ b/src/io/input.h
@@ -1,17 +1,17 @@
 /*
     gebaar
     Copyright (C) 2019   coffee2code
-    
+
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -31,6 +31,13 @@ namespace gebaar::io {
         double y;
     };
 
+    struct gesture_pinch_event {
+        int fingers;
+        double scale;
+        double angle;
+        bool executed;
+    };
+
     class Input {
     public:
         Input(std::shared_ptr<gebaar::config::Config> const& config_ptr);
@@ -48,6 +55,7 @@ namespace gebaar::io {
         struct libinput_event* libinput_event;
         struct udev* udev;
         struct gesture_swipe_event gesture_swipe_event;
+        struct gesture_pinch_event gesture_pinch_event;
 
         bool initialize_context();
 
@@ -74,6 +82,9 @@ namespace gebaar::io {
         void handle_swipe_event_without_coords(libinput_event_gesture* gev, bool begin);
 
         void handle_swipe_event_with_coords(libinput_event_gesture* gev);
+
+        void handle_pinch_event(libinput_event_gesture* gev, bool begin);
+
     };
 }
 


### PR DESCRIPTION
Basic implementation enables one shot pinch gesture.
That is the command from config file will run only once as soon as
fingers move 50% the distance between the fingers.