### PR TITLE
Configurable 2 fingers pinch gesture

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,16 @@ right_down = ""
 down = ""
 left = ""
 right = ""
+
+[commands.pinch]
+in = ""
+out = ""
+distance=""
 ```
+
+* `distance` variable in `commands.pinch` sets the distance between fingers where it shold trigger.
+  Defaults to `0.5` which means fingers should travel exactly half way from their initial position.
+
 
 ### Repository versions
 
@@ -77,6 +86,7 @@ down = "bspc node -f south"
 left = "bspc node -f west"
 right = "bspc node -f east"
 
+
 [commands.swipe.four]
 left_up = ""
 right_up = ""
@@ -86,6 +96,11 @@ right_down = ""
 down = ""
 left = "bspc desktop -f prev"
 right = "bspc desktop -f next"
+
+[commands.pinch]
+in = "xdotool key Control_L+equal"
+out = "xdotool key Control_L+minus"
+ditance="0.1"
 ```
 
 Add `gebaard -b` to `~/.config/bspwm/bspwmrc`
@@ -93,9 +108,12 @@ Add `gebaard -b` to `~/.config/bspwm/bspwmrc`
 ### State of the project
 
 - [x] Receiving swipe events from libinput
-- [ ] Receiving pinch/zoom events from libinput
+- [x] Receiving pinch/zoom events from libinput
+  - [ ] Support continous pinch
+  - [ ] Support pinch-and-rotate gestures
 - [ ] Receiving rotation events from libinput
 - [x] Converting libinput events to motions
 - [x] Running commands based on motions
 - [x] Refactor code to be up to Release standards, instead of testing-hell
+
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1,17 +1,17 @@
 /*
     gebaar
     Copyright (C) 2019   coffee2code
-    
+
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -60,6 +60,10 @@ void gebaar::config::Config::load_config()
             swipe_four_commands[7] = *config->get_qualified_as<std::string>("commands.swipe.four.left_down");
             swipe_four_commands[8] = *config->get_qualified_as<std::string>("commands.swipe.four.down");
             swipe_four_commands[9] = *config->get_qualified_as<std::string>("commands.swipe.four.right_down");
+
+            pinch_commands[PINCH_IN] = *config->get_qualified_as<std::string>("commands.pinch.out");
+            pinch_commands[PINCH_OUT] = *config->get_qualified_as<std::string>("commands.pinch.in");
+            pinch_commands[DISTANCE] = *config->get_qualified_as<std::string>("commands.pinch.distance");
 
             loaded = true;
         }

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -1,17 +1,17 @@
 /*
     gebaar
     Copyright (C) 2019   coffee2code
-    
+
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -33,8 +33,12 @@ namespace gebaar::config {
 
         void load_config();
 
+
+        enum pinches {PINCH_IN, PINCH_OUT, DISTANCE};
+
         std::string swipe_three_commands[10];
         std::string swipe_four_commands[10];
+        std::string pinch_commands[10];
 
     private:
         bool config_file_exists();

--- a/src/io/input.h
+++ b/src/io/input.h
@@ -1,17 +1,17 @@
 /*
     gebaar
     Copyright (C) 2019   coffee2code
-    
+
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-    
+
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -24,11 +24,24 @@
 #include <zconf.h>
 #include "../config/config.h"
 
+#define DEFAULT_SCALE    1.0
+#define DEFAULT_DISTANCE 0.5
+
+
 namespace gebaar::io {
     struct gesture_swipe_event {
         int fingers;
         double x;
         double y;
+    };
+
+    struct gesture_pinch_event {
+        int fingers;
+        double scale;
+        double angle;
+
+        double distance;
+        bool executed;
     };
 
     class Input {
@@ -48,6 +61,7 @@ namespace gebaar::io {
         struct libinput_event* libinput_event;
         struct udev* udev;
         struct gesture_swipe_event gesture_swipe_event;
+        struct gesture_pinch_event gesture_pinch_event;
 
         bool initialize_context();
 
@@ -74,6 +88,9 @@ namespace gebaar::io {
         void handle_swipe_event_without_coords(libinput_event_gesture* gev, bool begin);
 
         void handle_swipe_event_with_coords(libinput_event_gesture* gev);
+
+        void handle_pinch_event(libinput_event_gesture* gev, bool begin);
+
     };
 }
 


### PR DESCRIPTION
- Added pinch gestures
Basic implementation enables one shot pinch gesture.
That is the command from config file will run only once as soon as
fingers move 50% from the initial fingers position.

- Added a configurable distance variable to pinch gesture.
I felt that pinch gesture is kinda tricky to execute on touchpad,
so I changed a way of calculation when to trigger the command and
added the distance for fingers travel to configuration.
Basically a `0.5` distance feels quite ok to me, but it becomes really
snappy at `0.1`.