### PR TITLE
Feature/gesture threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,15 @@ right = ""
 [commands.pinch]
 in = ""
 out = ""
-distance=""
+
+[settings]
+pinch.distance = ""
+swipe.threshold = ""
 ```
 
-* `distance` variable in `commands.pinch` sets the distance between fingers where it shold trigger.
+* `settings.pinch.distance` key sets the distance between fingers where it shold trigger.
   Defaults to `0.5` which means fingers should travel exactly half way from their initial position.
-
+* `settings.swipe.threshold` sets the limit when swipe gesture should be executed. Defaults to 100.
 
 ### Repository versions
 
@@ -100,7 +103,10 @@ right = "bspc desktop -f next"
 [commands.pinch]
 in = "xdotool key Control_L+equal"
 out = "xdotool key Control_L+minus"
-ditance="0.1"
+
+[settings]
+pinch.ditance="0.5"
+swipe.threshold = "100"
 ```
 
 Add `gebaard -b` to `~/.config/bspwm/bspwmrc`

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -63,7 +63,9 @@ void gebaar::config::Config::load_config()
 
             pinch_commands[PINCH_IN] = *config->get_qualified_as<std::string>("commands.pinch.out");
             pinch_commands[PINCH_OUT] = *config->get_qualified_as<std::string>("commands.pinch.in");
-            pinch_commands[DISTANCE] = *config->get_qualified_as<std::string>("commands.pinch.distance");
+
+            settings[DISTANCE] = *config->get_qualified_as<std::string>("settings.pinch.distance");
+            settings[THRESHOLD] = *config->get_qualified_as<std::string>("settings.swipe.threshold");
 
             loaded = true;
         }

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -34,11 +34,13 @@ namespace gebaar::config {
         void load_config();
 
 
-        enum pinches {PINCH_IN, PINCH_OUT, DISTANCE};
+        enum pinch {PINCH_IN, PINCH_OUT};
+        enum settings {THRESHOLD, DISTANCE};
 
         std::string swipe_three_commands[10];
         std::string swipe_four_commands[10];
         std::string pinch_commands[10];
+        std::string settings[10];
 
     private:
         bool config_file_exists();

--- a/src/io/input.h
+++ b/src/io/input.h
@@ -24,8 +24,9 @@
 #include <zconf.h>
 #include "../config/config.h"
 
-#define DEFAULT_SCALE    1.0
-#define DEFAULT_DISTANCE 0.5
+#define DEFAULT_SCALE     1.0
+#define DEFAULT_DISTANCE  0.5
+#define DEFAULT_THRESHOLD 100
 
 
 namespace gebaar::io {
@@ -33,6 +34,9 @@ namespace gebaar::io {
         int fingers;
         double x;
         double y;
+
+        int threshold;
+        bool executed;
     };
 
     struct gesture_pinch_event {
@@ -85,9 +89,17 @@ namespace gebaar::io {
 
         void handle_event();
 
+        /* Swipe event */
+        void reset_swipe_event();
+
         void handle_swipe_event_without_coords(libinput_event_gesture* gev, bool begin);
 
         void handle_swipe_event_with_coords(libinput_event_gesture* gev);
+
+        void trigger_swipe_command();
+
+        /* Pinch event */
+        void reset_pinch_event();
 
         void handle_pinch_event(libinput_event_gesture* gev, bool begin);
 


### PR DESCRIPTION
This is a follow up for #29 

* Reorganized code a little bit
  - Previously swipe gesture was triggered only when fingers leaving
    touchpad thus threshold was useless. Moved trigger function outside
    of event handling.
  - Created reset functions for gestures to reset struct holding event
    data to default values.

* Added swipe threshold.
  - Added new config keys
    * `settings.pinch.distance` - now instead of
      `pinch.commands.distance` holds the value required for fingers to
      travel before executing pinch gesture.
    * `settings.swipe.threshold` - new key to set how long should be
      swipe to execute command.

This also closing #28 