### PR TITLE
2 fingers pinch gestures and thresholds for gestures

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,15 @@ right = ""
 [commands.pinch]
 in = ""
 out = ""
-distance=""
+
+[settings]
+pinch.distance = ""
+swipe.threshold = ""
 ```
 
-* `distance` variable in `commands.pinch` sets the distance between fingers where it shold trigger.
+* `settings.pinch.distance` key sets the distance between fingers where it shold trigger.
   Defaults to `0.5` which means fingers should travel exactly half way from their initial position.
-
+* `settings.swipe.threshold` sets the limit when swipe gesture should be executed. Defaults to 100.
 
 ### Repository versions
 
@@ -100,7 +103,10 @@ right = "bspc desktop -f next"
 [commands.pinch]
 in = "xdotool key Control_L+equal"
 out = "xdotool key Control_L+minus"
-ditance="0.1"
+
+[settings]
+pinch.ditance="0.5"
+swipe.threshold = "100"
 ```
 
 Add `gebaard -b` to `~/.config/bspwm/bspwmrc`

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ swipe.threshold = ""
 
 _~/.config/gebaar/gebaard.toml_
 ```toml
-[commands.swipe.three]
+[swipe.commands.three]
 left_up = ""
 right_up = ""
 up = "bspc node -f north"
@@ -91,7 +91,7 @@ left = "bspc node -f west"
 right = "bspc node -f east"
 
 
-[commands.swipe.four]
+[swipe.commands.four]
 left_up = ""
 right_up = ""
 up = "rofi -show combi"
@@ -101,13 +101,18 @@ down = ""
 left = "bspc desktop -f prev"
 right = "bspc desktop -f next"
 
-[commands.pinch]
+[pinch.commands.two]
 in = "xdotool key Control_L+equal"
 out = "xdotool key Control_L+minus"
 
-[settings]
-pinch.ditance="0.5"
-swipe.threshold = "100"
+[pinch.settings]
+threshold=0.25
+one_shot=false
+
+[swipe.settings]
+threshold = 0.5
+one_shot = true
+trigger_on_release = true
 ```
 
 Add `gebaard -b` to `~/.config/bspwm/bspwmrc`
@@ -117,8 +122,8 @@ Add `gebaard -b` to `~/.config/bspwm/bspwmrc`
 - [x] Receiving swipe events from libinput
 - [x] Swipe gesture have trigger treshold
 - [x] Receiving pinch/zoom events from libinput
-  - [ ] Support continous pinch
-  - [ ] Support pinch-and-rotate gestures
+- [x] Support continous pinch
+- [ ] Support pinch-and-rotate gestures
 - [ ] Receiving rotation events from libinput
 - [x] Converting libinput events to motions
 - [x] Running commands based on motions

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Add `gebaard -b` to `~/.config/bspwm/bspwmrc`
 ### State of the project
 
 - [x] Receiving swipe events from libinput
+- [x] Swipe gesture have trigger treshold
 - [x] Receiving pinch/zoom events from libinput
   - [ ] Support continous pinch
   - [ ] Support pinch-and-rotate gestures

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Gebaar
 =========
+Forked from Coffee2CodeNL/gebaar-libinput since original repo unmaintained for half a year.
 
 WM Independent Touchpad Gesture Daemon for libinput
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 Gebaar
 =========
-Forked from Coffee2CodeNL/gebaar-libinput since original repo unmaintained for half a year.
-
 WM Independent Touchpad Gesture Daemon for libinput
 
 _Gebaar means Gesture in Dutch_

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -63,7 +63,9 @@ void gebaar::config::Config::load_config()
 
             pinch_commands[PINCH_IN] = *config->get_qualified_as<std::string>("commands.pinch.out");
             pinch_commands[PINCH_OUT] = *config->get_qualified_as<std::string>("commands.pinch.in");
-            pinch_commands[DISTANCE] = *config->get_qualified_as<std::string>("commands.pinch.distance");
+
+            settings[DISTANCE] = *config->get_qualified_as<std::string>("settings.pinch.distance");
+            settings[THRESHOLD] = *config->get_qualified_as<std::string>("settings.swipe.threshold");
 
             loaded = true;
         }

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -64,8 +64,8 @@ void gebaar::config::Config::load_config()
             pinch_commands[PINCH_IN] = *config->get_qualified_as<std::string>("commands.pinch.out");
             pinch_commands[PINCH_OUT] = *config->get_qualified_as<std::string>("commands.pinch.in");
 
-            settings[DISTANCE] = *config->get_qualified_as<std::string>("settings.pinch.distance");
-            settings[THRESHOLD] = *config->get_qualified_as<std::string>("settings.swipe.threshold");
+            settings[PINCH_THRESHOLD] = *config->get_qualified_as<std::string>("settings.pinch.threshold");
+            settings[SWIPE_THRESHOLD] = *config->get_qualified_as<std::string>("settings.swipe.threshold");
 
             loaded = true;
         }

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -43,29 +43,37 @@ void gebaar::config::Config::load_config()
                 std::cerr << e.what() << std::endl;
                 exit(EXIT_FAILURE);
             }
-            swipe_three_commands[1] = *config->get_qualified_as<std::string>("commands.swipe.three.left_up");
-            swipe_three_commands[2] = *config->get_qualified_as<std::string>("commands.swipe.three.up");
-            swipe_three_commands[3] = *config->get_qualified_as<std::string>("commands.swipe.three.right_up");
-            swipe_three_commands[4] = *config->get_qualified_as<std::string>("commands.swipe.three.left");
-            swipe_three_commands[6] = *config->get_qualified_as<std::string>("commands.swipe.three.right");
-            swipe_three_commands[7] = *config->get_qualified_as<std::string>("commands.swipe.three.left_down");
-            swipe_three_commands[8] = *config->get_qualified_as<std::string>("commands.swipe.three.down");
-            swipe_three_commands[9] = *config->get_qualified_as<std::string>("commands.swipe.three.right_down");
 
-            swipe_four_commands[1] = *config->get_qualified_as<std::string>("commands.swipe.four.left_up");
-            swipe_four_commands[2] = *config->get_qualified_as<std::string>("commands.swipe.four.up");
-            swipe_four_commands[3] = *config->get_qualified_as<std::string>("commands.swipe.four.right_up");
-            swipe_four_commands[4] = *config->get_qualified_as<std::string>("commands.swipe.four.left");
-            swipe_four_commands[6] = *config->get_qualified_as<std::string>("commands.swipe.four.right");
-            swipe_four_commands[7] = *config->get_qualified_as<std::string>("commands.swipe.four.left_down");
-            swipe_four_commands[8] = *config->get_qualified_as<std::string>("commands.swipe.four.down");
-            swipe_four_commands[9] = *config->get_qualified_as<std::string>("commands.swipe.four.right_down");
+            /* Swipe Settings */
+            swipe_three_commands[1] = *config->get_qualified_as<std::string>("swipe.commands.three.left_up");
+            swipe_three_commands[2] = *config->get_qualified_as<std::string>("swipe.commands.three.up");
+            swipe_three_commands[3] = *config->get_qualified_as<std::string>("swipe.commands.three.right_up");
+            swipe_three_commands[4] = *config->get_qualified_as<std::string>("swipe.commands.three.left");
+            swipe_three_commands[6] = *config->get_qualified_as<std::string>("swipe.commands.three.right");
+            swipe_three_commands[7] = *config->get_qualified_as<std::string>("swipe.commands.three.left_down");
+            swipe_three_commands[8] = *config->get_qualified_as<std::string>("swipe.commands.three.down");
+            swipe_three_commands[9] = *config->get_qualified_as<std::string>("swipe.commands.three.right_down");
 
-            pinch_commands[PINCH_IN] = *config->get_qualified_as<std::string>("commands.pinch.out");
-            pinch_commands[PINCH_OUT] = *config->get_qualified_as<std::string>("commands.pinch.in");
+            swipe_four_commands[1] = *config->get_qualified_as<std::string>("swipe.commands.four.left_up");
+            swipe_four_commands[2] = *config->get_qualified_as<std::string>("swipe.commands.four.up");
+            swipe_four_commands[3] = *config->get_qualified_as<std::string>("swipe.commands.four.right_up");
+            swipe_four_commands[4] = *config->get_qualified_as<std::string>("swipe.commands.four.left");
+            swipe_four_commands[6] = *config->get_qualified_as<std::string>("swipe.commands.four.right");
+            swipe_four_commands[7] = *config->get_qualified_as<std::string>("swipe.commands.four.left_down");
+            swipe_four_commands[8] = *config->get_qualified_as<std::string>("swipe.commands.four.down");
+            swipe_four_commands[9] = *config->get_qualified_as<std::string>("swipe.commands.four.right_down");
 
-            settings[PINCH_THRESHOLD] = *config->get_qualified_as<std::string>("settings.pinch.threshold");
-            settings[SWIPE_THRESHOLD] = *config->get_qualified_as<std::string>("settings.swipe.threshold");
+            settings.swipe_threshold = config->get_qualified_as<double>("swipe.settings.threshold").value_or(0.5);
+            settings.swipe_one_shot = config->get_qualified_as<bool>("swipe.settings.one_shot").value_or(true);
+            settings.swipe_trigger_on_release = config->get_qualified_as<bool>("swipe.settings.trigger_on_release").value_or(true);
+
+            /* Pinch settings */
+            pinch_commands[PINCH_IN] = *config->get_qualified_as<std::string>("pinch.commands.two.out");
+            pinch_commands[PINCH_OUT] = *config->get_qualified_as<std::string>("pinch.commands.two.in");
+
+            settings.pinch_threshold = config->get_qualified_as<double>("pinch.settings.threshold").value_or(0.25);
+            settings.pinch_one_shot = config->get_qualified_as<bool>("pinch.settings.one_shot").value_or(false);
+
 
             loaded = true;
         }

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -35,7 +35,7 @@ namespace gebaar::config {
 
 
         enum pinch {PINCH_IN, PINCH_OUT};
-        enum settings {THRESHOLD, DISTANCE};
+        enum settings {SWIPE_THRESHOLD, PINCH_THRESHOLD};
 
         std::string swipe_three_commands[10];
         std::string swipe_four_commands[10];

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -34,21 +34,31 @@ namespace gebaar::config {
         void load_config();
 
 
-        enum pinch {PINCH_IN, PINCH_OUT};
-        enum settings {SWIPE_THRESHOLD, PINCH_THRESHOLD};
+        struct settings {
+          bool pinch_one_shot;
+          double pinch_threshold;
 
+          bool swipe_one_shot;
+          double swipe_threshold;
+          bool swipe_trigger_on_release;
+        } settings;
+
+        enum pinch {PINCH_IN, PINCH_OUT};
         std::string swipe_three_commands[10];
         std::string swipe_four_commands[10];
         std::string pinch_commands[10];
-        std::string settings[10];
 
     private:
+
         bool config_file_exists();
 
         bool find_config_file();
 
+
         std::string config_file_path;
         std::shared_ptr<cpptoml::table> config;
+
+
     };
 }
 #endif //GEBAAR_CONFIG_H

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -34,11 +34,13 @@ namespace gebaar::config {
         void load_config();
 
 
-        enum pinches {PINCH_IN, PINCH_OUT, DISTANCE};
+        enum pinch {PINCH_IN, PINCH_OUT};
+        enum settings {THRESHOLD, DISTANCE};
 
         std::string swipe_three_commands[10];
         std::string swipe_four_commands[10];
         std::string pinch_commands[10];
+        std::string settings[10];
 
     private:
         bool config_file_exists();

--- a/src/io/input.h
+++ b/src/io/input.h
@@ -24,8 +24,9 @@
 #include <zconf.h>
 #include "../config/config.h"
 
-#define DEFAULT_SCALE    1.0
-#define DEFAULT_DISTANCE 0.5
+#define DEFAULT_SCALE     1.0
+#define DEFAULT_DISTANCE  0.5
+#define DEFAULT_THRESHOLD 100
 
 
 namespace gebaar::io {
@@ -33,6 +34,9 @@ namespace gebaar::io {
         int fingers;
         double x;
         double y;
+
+        int threshold;
+        bool executed;
     };
 
     struct gesture_pinch_event {
@@ -85,9 +89,17 @@ namespace gebaar::io {
 
         void handle_event();
 
+        /* Swipe event */
+        void reset_swipe_event();
+
         void handle_swipe_event_without_coords(libinput_event_gesture* gev, bool begin);
 
         void handle_swipe_event_with_coords(libinput_event_gesture* gev);
+
+        void trigger_swipe_command();
+
+        /* Pinch event */
+        void reset_pinch_event();
 
         void handle_pinch_event(libinput_event_gesture* gev, bool begin);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,7 @@ int main(int argc, char* argv[])
     }
     std::shared_ptr<gebaar::config::Config> config = std::make_shared<gebaar::config::Config>();
     input = new gebaar::io::Input(config);
+
     if (input->initialize()) {
         input->start_loop();
     }


### PR DESCRIPTION
This commit introduces breaking changes due to changes in config file
format.

* Added swipe threshold.
* Added a configurable treshold variable to pinch gesture.
    I felt that pinch gesture is kinda tricky to execute on touchpad,
    so I changed a way of calculation when to trigger the command and
    added the distance for fingers travel to configuration.
    Basically a `0.5` distance feels quite ok to me, but it becomes really
    snappy at `0.1`.

* Reorganized code a little bit
  - Previously swipe gesture was triggered only when fingers leaving
    touchpad thus threshold was useless. Moved trigger function outside
    of event handling.
  - Created reset functions for gestures to reset struct holding event
    data to default values.


* Config keys changed format, see readme for examples.

* Both swipe and pinch gestures now have `settings.threshold` key which can be
  values 0.0 - 1.0.
  Defaults:
    Swipe: 1.0
    Pinch: 0.25
* Both swipe and pinch now have `settings.one_shot` which, if set,
  allows only one execution of command per gesture.
  Defaults:
    Swipe: true
    Pinch: false
* Swipe gesture now has `settings.trigger_on_release` defaulting to
  false. If set to true the command for swipe will be triggered when
  fingers are moved from touchpad UNLESS it is also one_shot gesture and
  gesture was already triggered.